### PR TITLE
Fix leak in linear history.

### DIFF
--- a/lib/resque/plugins/job_history.rb
+++ b/lib/resque/plugins/job_history.rb
@@ -10,7 +10,7 @@ module Resque
     module JobHistory
       extend ActiveSupport::Concern
 
-      # Redis mapp:
+      # Redis map:
       #   job_history - a set of all of the class names of all jobs
       #   job_history..linear_jobs - a list of the IDs for all jobs that have run in the order
       #                                          they were started.

--- a/lib/resque/plugins/job_history/cleaner.rb
+++ b/lib/resque/plugins/job_history/cleaner.rb
@@ -48,6 +48,8 @@ module Resque
               purge_class class_name
             end
 
+            purge_linear_history
+
             del_key(Resque::Plugins::JobHistory::HistoryDetails.job_history_key, "Purging job_history_key")
 
             redis.keys("*").each do |key|

--- a/lib/resque/plugins/job_history/history_list.rb
+++ b/lib/resque/plugins/job_history/history_list.rb
@@ -86,11 +86,13 @@ module Resque
         end
 
         def delete_old_jobs(job_count)
-          while job_count > max_jobs
-            job_id = redis.rpop(job_list_key)
+          while num_jobs > max_jobs
+            job_id         = redis.rpop(job_list_key)
+            job_class_name = job_class(job_id)
+
             remove_job_data(job_id)
 
-            Resque::Plugins::JobHistory::Job.new(job_class(job_id), job_id).safe_purge
+            Resque::Plugins::JobHistory::Job.new(job_class_name, job_id).safe_purge
 
             job_count -= 1
           end

--- a/resque-job_history.gemspec
+++ b/resque-job_history.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "resque-job_history"
-  s.version     = "0.0.17"
+  s.version     = "0.0.18"
   s.authors     = ["RealNobody"]
   s.email       = ["RealNobody1@cox.net"]
   s.homepage    = "https://github.com/RealNobody"

--- a/spec/job_history/cleaner_spec.rb
+++ b/spec/job_history/cleaner_spec.rb
@@ -282,8 +282,9 @@ RSpec.describe Resque::Plugins::JobHistory::Cleaner do
     end
 
     it "fixes linear keys" do
-      expect(cleaner).to receive(:fixup_linear_keys).and_call_original
+      allow(cleaner).to receive(:fixup_linear_keys).and_call_original
       cleaner.purge_linear_history
+      expect(cleaner).to have_received(:fixup_linear_keys)
     end
 
     it "purges unknown keys" do

--- a/spec/support/jobs/linear_history_length_jobs.rb
+++ b/spec/support/jobs/linear_history_length_jobs.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class LinearOneJob < BasicJob
+  @job_history_len = 10
+end
+
+class LinearTwoJob < BasicJob
+  @job_history_len = 10
+end
+
+class LinearThreeJob < BasicJob
+  @job_history_len = 10
+end


### PR DESCRIPTION
Jobs are "leaking" when they drop off of the job list before they drop off of the linear history.

When they are dropped off of the linear history, they aren't deleted properly and end up sticking around.