### PR TITLE
Use redis.exists? instead redis.exists

### DIFF
--- a/lib/resque/plugins/job_history/job.rb
+++ b/lib/resque/plugins/job_history/job.rb
@@ -29,7 +29,7 @@ module Resque
         end
 
         def blank?
-          !redis.exists job_key
+          !redis.exists? job_key
         end
 
         def succeeded?


### PR DESCRIPTION
This is to address warning from `redis-namespace`:
```
Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0.
```